### PR TITLE
Refactor to remove the need to continously check the state of locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+2.0.0
+ - Remove interval from dreadlock constructor
+ - Refactor to remove need for interval
+ - Dreadlock constructor now takes a configuration object
+ - Add lockTimeout mechanism
+ - Refactor tests and introduce jest
+ - Update readme
+ - Add this changelog

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # dreadlocks
 Dread-free locks that drive consistency.
 
-### Summary
+## Summary
+
+Dreadlocks allows you to create deadlocks on a set of keys. There is no limitation as to what key can
+be, it could be an `Object`, an `Array`, a `String`, or anything that can be a key in `Map`.
 
 * Create and use keys to identify objects:
-  * `let key1 = hash(anything)`
+  * `const key1 = {};`
 * Create key sets for keys involved in each task:
   * `const keySet = [key1, key2, key3]`
 * Lock these key sets
@@ -30,22 +33,40 @@ Dread-free locks that drive consistency.
 
 ---
 
-### class `Dreadlock`
-* constructor (`interval`)
-  * `interval` optional Integer, in ms
-* lock (`items`)
-  * `items` array of keys to lock
-  * RETURNS Promise, resolves on lock success
-* release (`items`)
-  * `items` array of keys to release
-  * RETURNS Promise, resolves on release success
-* size
-  * RETURNS current size of instance `Map`
+## API
+
+### Constructor
+
+#### `new Dreadlocks({ defaultLockTimeout = Infinity })`
+
+Construct an instance of Dreadlock. You can also set a default timeout to wait for
+a lock.
+
+### Methods
+
+#### `#lock(keyset[], { lockTimeout = this.defaultLockTimeout } = {})`
+
+* `keyset` array of keys to lock
+* `lockTimeout` timeout in ms for the lock to be obtained
+
+Return a `Promise` which will resolve when the lock is obtained, or reject when the
+timeout is reached.
+
+#### `#release(keyset[])`
+
+* `keyset` array of keys to release
+
+### Properties
+
+#### `#size`
+
+Current size of instance `Map`
+
 ---
 
-### Usage:
+## Usage:
 
-* Install:
+### Install
 ```
 npm install dreadlocks --save
 yarn add dreadlocks
@@ -54,12 +75,12 @@ yarn add dreadlocks
 const Dreadlock = require('dreadlocks');
 ```
 
-* Create instance:
+### Create instance
 ```
 const Dread = new Dreadlock();
 ```
 
-* Lock your keys anywhere in your code:
+### Lock your keys anywhere in your code:
 ```
 const keySet1 = ['key1', 'key2', 'key3'];
 Dread.lock(keySet1)
@@ -86,7 +107,7 @@ Dread.lock(keySet2)
     console.log('keySet2 released.');
   });
 ```
-* See the magic:
+###  See the magic:
 ```
 Working with keySet1.
 Done with keySet1.
@@ -98,6 +119,6 @@ keySet2 released.
 
 ---
 
-### LICENSE
+## LICENSE
 
 ![C](https://upload.wikimedia.org/wikipedia/commons/8/84/Public_Domain_Mark_button.svg) ![0](https://upload.wikimedia.org/wikipedia/commons/6/69/CC0_button.svg)

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "dreadlocks",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Dread-free locks that drive consistency.",
   "main": "index.js",
   "scripts": {
-    "test": "node test.js"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -23,5 +23,9 @@
   "bugs": {
     "url": "https://github.com/xemasiv/dreadlocks/issues"
   },
-  "homepage": "https://github.com/xemasiv/dreadlocks#readme"
+  "homepage": "https://github.com/xemasiv/dreadlocks#readme",
+  "dependencies": {
+    "debug": "^3.1.0",
+    "jest": "^22.4.3"
+  }
 }

--- a/test.js
+++ b/test.js
@@ -1,27 +1,108 @@
 const Dreadlock = require('./index');
 
-const Dread = new Dreadlock();
+const exhaustPromiseQueue = async () => {
+  for (let i = 0; i < 1000; i++) {
+    await Promise.resolve();
+  }
+};
 
-const keySet1 = ['key1', 'key2', 'key3'];
-Dread.lock(keySet1)
-  .then(() => {
-    console.log('Working with keySet1.');
-    // Use your keySet1 keys here
-    console.log('Done with keySet1.');
-    return Dread.release(keySet1);
-  })
-  .then(() => {
-    console.log('keySet1 released.');
-  });
+it('basic lock should work', async () => {
+  jest.useFakeTimers();
 
-const keySet2 = ['key1', 'key4', 'key5'];
-Dread.lock(keySet2)
-  .then(() => {
-    console.log('Working with keySet2.');
-    // Use your keySet2 keys here
-    console.log('Done with keySet2.');
-    return Dread.release(keySet2);
-  })
-  .then(() => {
-    console.log('keySet2 released.');
-  });
+  const dread = new Dreadlock();
+  const keySet1 = ['key1', 'key2', 'key3'];
+  const keySet2 = ['key1', 'key4', 'key5'];
+
+  const spy1 = jest.fn();
+  const spy2 = jest.fn();
+
+  dread.lock(keySet1)
+    .then(spy1);
+
+  dread.lock(keySet2)
+    .then(spy2);
+
+  jest.advanceTimersByTime(10000);
+  await exhaustPromiseQueue();
+
+  expect(spy1).toHaveBeenCalled();
+  expect(spy2).not.toHaveBeenCalled();
+
+  dread.release(['key2']);
+
+  jest.advanceTimersByTime(10000);
+  await exhaustPromiseQueue();
+
+  expect(spy2).not.toHaveBeenCalled();
+
+  dread.release(['key1']);
+
+  jest.advanceTimersByTime(10000);
+  await exhaustPromiseQueue();
+
+  expect(spy2).toHaveBeenCalled();
+});
+
+it('timeout waiting for lock', async () => {
+  jest.useFakeTimers();
+
+  const dread = new Dreadlock({ defaultLockTimeout: 60000 });
+  const keySet1 = ['key1', 'key2', 'key3'];
+  const keySet2 = ['key1', 'key4', 'key5'];
+
+  const spy1 = jest.fn();
+  const spy2 = jest.fn();
+
+  dread.lock(keySet1)
+    .then(spy1);
+
+  dread.lock(keySet2)
+    .then(spy2, spy2);
+
+  jest.advanceTimersByTime(65000);
+  await exhaustPromiseQueue();
+
+  expect(spy1).toHaveBeenCalled();
+  expect(spy2).toHaveBeenCalledWith(new Error('timeout waiting for lock'));
+});
+
+it('resume after timeout', async () => {
+  jest.useFakeTimers();
+
+  const dread = new Dreadlock({ defaultLockTimeout: 60000 });
+  const keySet1 = ['key1', 'key2', 'key3'];
+  const keySet2 = ['key1', 'key4', 'key5'];
+  const keySet3 = ['key1'];
+
+  const spy1 = jest.fn();
+  const spy2 = jest.fn();
+  const spy3 = jest.fn();
+
+  dread.lock(keySet1)
+    .then(spy1);
+
+  dread.lock(keySet2)
+    .then(spy2, spy2);
+
+  jest.advanceTimersByTime(65000);
+  await exhaustPromiseQueue();
+
+  expect(spy1).toHaveBeenCalled();
+  expect(spy2).toHaveBeenCalledWith(new Error('timeout waiting for lock'));
+  expect(spy3).not.toHaveBeenCalled();
+
+  dread.lock(keySet3)
+    .then(spy3);
+
+  jest.advanceTimersByTime(10000);
+  await exhaustPromiseQueue();
+
+  expect(spy3).not.toHaveBeenCalled();
+
+  dread.release(keySet1);
+  jest.advanceTimersByTime(65000);
+  await exhaustPromiseQueue();
+
+  expect(spy1.mock.calls.length).toBe(1);
+  expect(spy3).toHaveBeenCalled();
+});


### PR DESCRIPTION
 - Remove interval from dreadlock constructor
 - Refactor to remove need for interval
 - Dreadlock constructor now takes a configuration object
 - Add lockTimeout mechanism
 - Refactor tests and introduce jest
 - Update readme
 - Add the changelog